### PR TITLE
Add node version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "package-johnson",
   "version": "1.0.0",
   "description": "",
+  "engines": {
+    "node": "14.16.1"
+  },
   "main": "package-johnson",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
Discord.js has a bug with voice connections in node versions above 14.16.1, so I just fixed the node version in package.json for heroku.